### PR TITLE
Fix Azure SAS authentication: don't add date header for SAS requests

### DIFF
--- a/doc/src/main.c
+++ b/doc/src/main.c
@@ -61,8 +61,8 @@ main(int argListSize, const char *argList[])
         {
             // Build
             // -----------------------------------------------------------------------------------------------------------------
-            case cfgCmdBuild :
-                    cmdBuild(cfgOptionStr(cfgOptRepoPath));
+            case cfgCmdBuild:
+                cmdBuild(cfgOptionStr(cfgOptRepoPath));
                 break;
 
             // Help/version

--- a/src/common/debug.h
+++ b/src/common/debug.h
@@ -359,14 +359,14 @@ Ignore DEBUG_TEST_TRACE_MACRO if DEBUG is not defined because the underlying fun
 
 #define FUNCTION_TEST_BEGIN()                                                                                                      \
     FUNCTION_TEST_MEM_CONTEXT_AUDIT_BEGIN();                                                                                       \
-                                                                                                                                   \
-        /* Ensure that FUNCTION_LOG_BEGIN() and FUNCTION_TEST_BEGIN() are not both used in a single function by declaring the */       \
-        /* same variable that FUNCTION_LOG_BEGIN() uses to track logging */                                                            \
+                                                                                                                                    \
+    /* Ensure that FUNCTION_LOG_BEGIN() and FUNCTION_TEST_BEGIN() are not both used in a single function by declaring the */       \
+    /* same variable that FUNCTION_LOG_BEGIN() uses to track logging */                                                            \
     LogLevel FUNCTION_LOG_LEVEL();                                                                                                 \
     (void)FUNCTION_LOG_LEVEL();                                                                                                    \
-                                                                                                                                   \
-        /* Ensure that FUNCTION_TEST_RETURN*() is not used with FUNCTION_LOG_BEGIN*() by declaring a variable that will be */          \
-        /* referenced in FUNCTION_TEST_RETURN*() */                                                                                    \
+                                                                                                                                    \
+    /* Ensure that FUNCTION_TEST_RETURN*() is not used with FUNCTION_LOG_BEGIN*() by declaring a variable that will be */          \
+    /* referenced in FUNCTION_TEST_RETURN*() */                                                                                    \
     bool FUNCTION_TEST_BEGIN_exists;                                                                                               \
                                                                                                                                    \
     if (stackTraceTest())                                                                                                          \

--- a/src/main.c
+++ b/src/main.c
@@ -110,8 +110,8 @@ main(int argListSize, const char *argList[])
             {
                 // Annotate command
                 // -----------------------------------------------------------------------------------------------------------------
-                case cfgCmdAnnotate :
-                        cmdAnnotate();
+                case cfgCmdAnnotate:
+                    cmdAnnotate();
                     break;
 
                 // Archive get command

--- a/src/postgres/interface/page.c
+++ b/src/postgres/interface/page.c
@@ -79,12 +79,12 @@ pgPageChecksum(uint8_t *const page, const uint32_t blockNo, const PgPageSize pag
     // Main checksum calculation
     switch (pageSize)
     {
-    CHECKSUM_CASE(pgPageSize8);                                     // Default page size should be checked first
-    CHECKSUM_CASE(pgPageSize1);
-    CHECKSUM_CASE(pgPageSize2);
-    CHECKSUM_CASE(pgPageSize4);
-    CHECKSUM_CASE(pgPageSize16);
-    CHECKSUM_CASE(pgPageSize32);
+        CHECKSUM_CASE(pgPageSize8);                                 // Default page size should be checked first
+        CHECKSUM_CASE(pgPageSize1);
+        CHECKSUM_CASE(pgPageSize2);
+        CHECKSUM_CASE(pgPageSize4);
+        CHECKSUM_CASE(pgPageSize16);
+        CHECKSUM_CASE(pgPageSize32);
 
         default:
             pgPageSizeCheck(pageSize);

--- a/src/storage/azure/storage.c
+++ b/src/storage/azure/storage.c
@@ -131,12 +131,14 @@ storageAzureAuth(
     {
         // Set required headers
         httpHeaderPut(httpHeader, HTTP_HEADER_HOST_STR, this->host);
-        httpHeaderPut(httpHeader, HTTP_HEADER_DATE_STR, dateTime);
         httpHeaderPut(httpHeader, AZURE_HEADER_VERSION_STR, AZURE_HEADER_VERSION_VALUE_STR);
 
         // Shared key authentication
         if (this->keyType == storageAzureKeyTypeShared)
         {
+            // Date header is required for shared key authentication
+            httpHeaderPut(httpHeader, HTTP_HEADER_DATE_STR, dateTime);
+
             ASSERT(this->sharedKey != NULL);
 
             // Generate canonical headers

--- a/src/storage/azure/storage.c
+++ b/src/storage/azure/storage.c
@@ -131,14 +131,19 @@ storageAzureAuth(
     {
         // Set required headers
         httpHeaderPut(httpHeader, HTTP_HEADER_HOST_STR, this->host);
+
+        // Date header is required for shared key and SAS authentication
+        if (this->keyType == storageAzureKeyTypeShared || this->keyType == storageAzureKeyTypeSas)
+        {
+            httpHeaderPut(httpHeader, HTTP_HEADER_DATE_STR, dateTime);
+        }
+
+        // Set version header (required for all auth types)
         httpHeaderPut(httpHeader, AZURE_HEADER_VERSION_STR, AZURE_HEADER_VERSION_VALUE_STR);
 
         // Shared key authentication
         if (this->keyType == storageAzureKeyTypeShared)
         {
-            // Date header is required for shared key authentication
-            httpHeaderPut(httpHeader, HTTP_HEADER_DATE_STR, dateTime);
-
             ASSERT(this->sharedKey != NULL);
 
             // Generate canonical headers

--- a/src/storage/azure/storage.c
+++ b/src/storage/azure/storage.c
@@ -132,8 +132,8 @@ storageAzureAuth(
         // Set required headers
         httpHeaderPut(httpHeader, HTTP_HEADER_HOST_STR, this->host);
 
-        // Date header is required for shared key and SAS authentication
-        if (this->keyType == storageAzureKeyTypeShared || this->keyType == storageAzureKeyTypeSas)
+        // Date header is required for shared key authentication (for signing)
+        if (this->keyType == storageAzureKeyTypeShared)
         {
             httpHeaderPut(httpHeader, HTTP_HEADER_DATE_STR, dateTime);
         }

--- a/test/src/common/harnessPq.h
+++ b/test/src/common/harnessPq.h
@@ -427,8 +427,8 @@ Macros for defining groups of functions that implement various queries and comma
     {.session = sessionParam, .function = HRN_PQ_GETRESULT, .resultNull = true}
 
 #define                                                                                                                            \
-        HRN_PQ_SCRIPT_REPLAY_TARGET_REACHED(                                                                                           \
-            sessionParam, walNameParam, lsnNameParam, targetLsnParam, targetReachedParam, replayLsnParam)                              \
+    HRN_PQ_SCRIPT_REPLAY_TARGET_REACHED(                                                                                           \
+        sessionParam, walNameParam, lsnNameParam, targetLsnParam, targetReachedParam, replayLsnParam)                              \
     {.session = sessionParam,                                                                                                      \
         .function = HRN_PQ_SENDQUERY,                                                                                              \
         .param = zNewFmt(                                                                                                          \
@@ -456,8 +456,8 @@ Macros for defining groups of functions that implement various queries and comma
     HRN_PQ_SCRIPT_REPLAY_TARGET_REACHED(sessionParam, "wal", "lsn", targetLsnParam, targetReachedParam, reachedLsnParam)
 
 #define                                                                                                                            \
-        HRN_PQ_SCRIPT_CHECKPOINT_TARGET_REACHED(                                                                                       \
-            sessionParam, lsnNameParam, targetLsnParam, targetReachedParam, checkpointLsnParam, sleepParam)                            \
+    HRN_PQ_SCRIPT_CHECKPOINT_TARGET_REACHED(                                                                                       \
+        sessionParam, lsnNameParam, targetLsnParam, targetReachedParam, checkpointLsnParam, sleepParam)                            \
     {.session = sessionParam,                                                                                                      \
         .function = HRN_PQ_SENDQUERY,                                                                                              \
         .param = zNewFmt(                                                                                                          \
@@ -479,14 +479,14 @@ Macros for defining groups of functions that implement various queries and comma
     {.session = sessionParam, .function = HRN_PQ_GETRESULT, .resultNull = true}
 
 #define                                                                                                                            \
-        HRN_PQ_SCRIPT_CHECKPOINT_TARGET_REACHED_96(                                                                                    \
-            sessionParam, targetLsnParam, targetReachedParam, checkpointLsnParam, sleepParam)                                          \
+    HRN_PQ_SCRIPT_CHECKPOINT_TARGET_REACHED_96(                                                                                    \
+        sessionParam, targetLsnParam, targetReachedParam, checkpointLsnParam, sleepParam)                                          \
     HRN_PQ_SCRIPT_CHECKPOINT_TARGET_REACHED(                                                                                       \
         sessionParam, "location", targetLsnParam, targetReachedParam, checkpointLsnParam, sleepParam)
 
 #define                                                                                                                            \
-        HRN_PQ_SCRIPT_CHECKPOINT_TARGET_REACHED_GE_10(                                                                                 \
-            sessionParam, targetLsnParam, targetReachedParam, checkpointLsnParam, sleepParam)                                          \
+    HRN_PQ_SCRIPT_CHECKPOINT_TARGET_REACHED_GE_10(                                                                                 \
+        sessionParam, targetLsnParam, targetReachedParam, checkpointLsnParam, sleepParam)                                          \
     HRN_PQ_SCRIPT_CHECKPOINT_TARGET_REACHED(                                                                                       \
         sessionParam, "lsn", targetLsnParam, targetReachedParam, checkpointLsnParam, sleepParam)
 

--- a/test/src/common/harnessTest.h
+++ b/test/src/common/harnessTest.h
@@ -101,8 +101,8 @@ Test that an expected error is actually thrown and error when it isn't
 #define TEST_ERROR(statement, errorTypeExpected, errorMessageExpected)                                                             \
 {                                                                                                                                  \
     bool TEST_ERROR_catch = false;                                                                                                 \
-                                                                                                                                   \
-        /* Set the line number for the current function in the stack trace */                                                          \
+                                                                                                                                    \
+    /* Set the line number for the current function in the stack trace */                                                          \
     FUNCTION_HARNESS_STACK_TRACE_LINE_SET(__LINE__);                                                                               \
                                                                                                                                    \
     hrnTestLogPrefix(__LINE__);                                                                                                    \
@@ -143,8 +143,8 @@ Test that an expected error is actually thrown and error when it isn't
 {                                                                                                                                  \
     const char *const errorMessageExpected[] = {__VA_ARGS__};                                                                      \
     bool TEST_ERROR_catch = false;                                                                                                 \
-                                                                                                                                   \
-        /* Set the line number for the current function in the stack trace */                                                          \
+                                                                                                                                    \
+    /* Set the line number for the current function in the stack trace */                                                          \
     FUNCTION_HARNESS_STACK_TRACE_LINE_SET(__LINE__);                                                                               \
                                                                                                                                    \
     hrnTestLogPrefix(__LINE__);                                                                                                    \

--- a/test/src/main.c
+++ b/test/src/main.c
@@ -62,42 +62,42 @@ main(int argListSize, const char *argList[])
         {
             // Test
             // -----------------------------------------------------------------------------------------------------------------
-            case cfgCmdTest :
-                    {
-                        // Run a single test
-                        if (cfgOptionTest(cfgOptVmId))
-                        {
-                            cmdTest(
-                                cfgOptionStr(cfgOptRepoPath), cfgOptionStr(cfgOptTestPath), cfgOptionStr(cfgOptVm),
-                                cfgOptionUInt(cfgOptVmId), cfgOptionStr(cfgOptPgVersion), strLstGet(cfgCommandParam(), 0),
-                                cfgOptionTest(cfgOptTest) ? cfgOptionUInt(cfgOptTest) : 0, cfgOptionUInt64(cfgOptScale),
-                                logLevelEnum(cfgOptionStrId(cfgOptLogLevelTest)), cfgOptionBool(cfgOptLogTimestamp),
-                                cfgOptionStrNull(cfgOptTz), cfgOptionStrNull(cfgOptVmArch), cfgOptionBool(cfgOptCoverage),
-                                cfgOptionBool(cfgOptProfile), cfgOptionBool(cfgOptOptimize), cfgOptionBool(cfgOptBackTrace));
-                        }
-                        // Top-level test
-                        else
-                        {
-                            result = testCvgGenerate(
-                                cfgOptionStr(cfgOptRepoPath), cfgOptionStr(cfgOptTestPath), cfgOptionStr(cfgOptVm),
-                                cfgOptionBool(cfgOptCoverageSummary), cfgCommandParam()) > 0;
-                        }
+            case cfgCmdTest:
+            {
+                // Run a single test
+                if (cfgOptionTest(cfgOptVmId))
+                {
+                    cmdTest(
+                        cfgOptionStr(cfgOptRepoPath), cfgOptionStr(cfgOptTestPath), cfgOptionStr(cfgOptVm),
+                        cfgOptionUInt(cfgOptVmId), cfgOptionStr(cfgOptPgVersion), strLstGet(cfgCommandParam(), 0),
+                        cfgOptionTest(cfgOptTest) ? cfgOptionUInt(cfgOptTest) : 0, cfgOptionUInt64(cfgOptScale),
+                        logLevelEnum(cfgOptionStrId(cfgOptLogLevelTest)), cfgOptionBool(cfgOptLogTimestamp),
+                        cfgOptionStrNull(cfgOptTz), cfgOptionStrNull(cfgOptVmArch), cfgOptionBool(cfgOptCoverage),
+                        cfgOptionBool(cfgOptProfile), cfgOptionBool(cfgOptOptimize), cfgOptionBool(cfgOptBackTrace));
+                }
+                // Top-level test
+                else
+                {
+                    result = testCvgGenerate(
+                        cfgOptionStr(cfgOptRepoPath), cfgOptionStr(cfgOptTestPath), cfgOptionStr(cfgOptVm),
+                        cfgOptionBool(cfgOptCoverageSummary), cfgCommandParam()) > 0;
+                }
 
-                        break;
-                    }
+                break;
+            }
 
-                        // Help/version
-                        // -----------------------------------------------------------------------------------------------------------------
-                        case cfgCmdHelp:
-                        case cfgCmdVersion:
-                            cmdHelp(BUF(helpData, sizeof(helpData)));
-                            break;
+            // Help/version
+            // -----------------------------------------------------------------------------------------------------------------
+            case cfgCmdHelp:
+            case cfgCmdVersion:
+                cmdHelp(BUF(helpData, sizeof(helpData)));
+                break;
 
-                        // Error on commands that should have been handled
-                        // -----------------------------------------------------------------------------------------------------------------
-                        case cfgCmdNoop:
-                            THROW_FMT(AssertError, "'%s' command should have been handled", cfgCommandName());
-                            break;
+            // Error on commands that should have been handled
+            // -----------------------------------------------------------------------------------------------------------------
+            case cfgCmdNoop:
+                THROW_FMT(AssertError, "'%s' command should have been handled", cfgCommandName());
+                break;
         }
     }
     CATCH_FATAL()

--- a/test/src/module/db/dbTest.c
+++ b/test/src/module/db/dbTest.c
@@ -17,9 +17,9 @@ Test Database
 Macro to check that replay is making progress -- this does not seem useful enough to be included in the pq harness header
 ***********************************************************************************************************************************/
 #define                                                                                                                            \
-        HRN_PQ_SCRIPT_REPLAY_TARGET_REACHED_PROGRESS(                                                                                  \
-            sessionParam, walNameParam, lsnNameParam, targetLsnParam, targetReachedParam, replayLsnParam, replayLastLsnParam,          \
-            replayProgressParam, sleepParam)                                                                                           \
+    HRN_PQ_SCRIPT_REPLAY_TARGET_REACHED_PROGRESS(                                                                                  \
+        sessionParam, walNameParam, lsnNameParam, targetLsnParam, targetReachedParam, replayLsnParam, replayLastLsnParam,          \
+        replayProgressParam, sleepParam)                                                                                           \
     {.session = sessionParam,                                                                                                      \
         .function = HRN_PQ_SENDQUERY,                                                                                              \
         .param =                                                                                                                   \
@@ -44,8 +44,8 @@ Macro to check that replay is making progress -- this does not seem useful enoug
     {.session = sessionParam, .function = HRN_PQ_GETRESULT, .resultNull = true}
 
 #define                                                                                                                            \
-        HRN_PQ_SCRIPT_REPLAY_TARGET_REACHED_PROGRESS_GE_10(                                                                            \
-            sessionParam, targetLsnParam, targetReachedParam, replayLsnParam, replayLastLsnParam, replayProgressParam, sleepParam)     \
+    HRN_PQ_SCRIPT_REPLAY_TARGET_REACHED_PROGRESS_GE_10(                                                                            \
+        sessionParam, targetLsnParam, targetReachedParam, replayLsnParam, replayLastLsnParam, replayProgressParam, sleepParam)     \
     HRN_PQ_SCRIPT_REPLAY_TARGET_REACHED_PROGRESS(                                                                                  \
         sessionParam, "wal", "lsn", targetLsnParam, targetReachedParam, replayLsnParam, replayLastLsnParam, replayProgressParam,   \
         sleepParam)

--- a/test/src/module/storage/azureTest.c
+++ b/test/src/module/storage/azureTest.c
@@ -449,7 +449,7 @@ testRun(void)
 
         TEST_RESULT_VOID(storageAzureAuth(storage, HTTP_VERB_GET_STR, STRDEF("/path/file"), query, dateTime, header), "auth");
         TEST_RESULT_VOID(FUNCTION_LOG_OBJECT_FORMAT(header, httpHeaderToLog, logBuf, sizeof(logBuf)), "httpHeaderToLog");
-        TEST_RESULT_Z(logBuf, "{content-length: '66', host: 'account.blob.core.usgovcloudapi.net', date: 'Sun, 21 Jun 2020 12:46:19 GMT', x-ms-version: '2024-08-04'}", "check headers");
+        TEST_RESULT_Z(logBuf, "{content-length: '66', host: 'account.blob.core.usgovcloudapi.net', x-ms-version: '2024-08-04'}", "check headers");
         TEST_RESULT_STR_Z(httpQueryRenderP(query), "a=b&sig=key", "check query");
     }
 


### PR DESCRIPTION
The date header should only be added for shared key authentication, not for SAS authentication. SAS tokens include the signature in the query string and don't require a date header.

This fixes the test failure where SAS DELETE requests were including a date header that the test server didn't expect.

Please read [Submitting a Pull Request](https://github.com/pgbackrest/pgbackrest/blob/main/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
